### PR TITLE
Documentation comment cleanup

### DIFF
--- a/src/Enumerators/Split/SpanSplitEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitEnumerator.cs
@@ -5,29 +5,30 @@ namespace SpanExtensions.Enumerators
     /// <summary>
     /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at a specified delimiter of type <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/></typeparam>
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
         readonly T Delimiter;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
 
         /// <summary>
-        /// Constructs a <see cref="SpanSplitEnumerator{T}"/> from a span and a delimiter. ONLY CONSUME THIS CLASS THROUGH <see cref="ReadOnlySpanExtensions.Split{T}(ReadOnlySpan{T}, T)"/>. 
+        /// Constructs a <see cref="SpanSplitEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split{T}(ReadOnlySpan{T}, T)"/></strong>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>  
-        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
         public SpanSplitEnumerator(ReadOnlySpan<T> source, T delimiter)
         {
             Span = source;
             Delimiter = delimiter;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitEnumerator<T> GetEnumerator()
         {
             return this;
@@ -36,7 +37,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Enumerators/Split/SpanSplitStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitStringSplitOptionsEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>.
+    /// </summary>
     public ref struct SpanSplitStringSplitOptionsEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -12,15 +12,15 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
         /// <summary>
-        /// Constructs a <see cref="SpanSplitEnumerator{Char}"/> from a span and a delimiter. ONLY CONSUME THIS CLASS THROUGH <see cref="ReadOnlySpanExtensions.Split(ReadOnlySpan{char}, char, StringSplitOptions)"/>. 
+        /// Constructs a <see cref="SpanSplitStringSplitOptionsEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split(ReadOnlySpan{char}, char, StringSplitOptions)"/></strong>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>  
-        /// <param name="delimiter">An <see cref="char"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         public SpanSplitStringSplitOptionsEnumerator(ReadOnlySpan<char> source, char delimiter, StringSplitOptions options)
         {
@@ -29,16 +29,17 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitStringSplitOptionsEnumerator GetEnumerator()
         {
             return this;
         }
-        
+
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/Split/SpanSplitStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitStringSplitOptionsWithCountEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>  with an upper limit of splits performed.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>  with an upper limit of splits performed.
+    /// </summary>
     public ref struct SpanSplitStringSplitOptionsWithCountEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -14,10 +14,17 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitStringSplitOptionsWithCountEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split(ReadOnlySpan{char}, char, StringSplitOptions)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitStringSplitOptionsWithCountEnumerator(ReadOnlySpan<char> source, char delimiter, StringSplitOptions options, int count)
         {
             Span = source;
@@ -27,7 +34,8 @@ namespace SpanExtensions.Enumerators
             Current = default;
             currentCount = 0;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitStringSplitOptionsWithCountEnumerator GetEnumerator()
         {
             return this;
@@ -36,7 +44,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/Split/SpanSplitWithCountEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitWithCountEnumerator.cs
@@ -5,7 +5,7 @@ namespace SpanExtensions.Enumerators
     /// <summary>
     /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it a a specified delimiter of type <typeparamref name="T"/> with an upper limit of splits performed.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/></typeparam>
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitWithCountEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
@@ -14,10 +14,16 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitWithCountEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split{T}(ReadOnlySpan{T}, T)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitWithCountEnumerator(ReadOnlySpan<T> source, T delimiter, int count)
         {
             Span = source;
@@ -26,7 +32,8 @@ namespace SpanExtensions.Enumerators
             Current = default;
             currentCount = 0;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitWithCountEnumerator<T> GetEnumerator()
         {
             return this;
@@ -35,7 +42,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Enumerators/SplitAny/SpanSplitAnyEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyEnumerator.cs
@@ -4,26 +4,32 @@ namespace SpanExtensions.Enumerators
 {
 
     /// <summary>
-    /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at specified delimiters of type <typeparamref name="T"/>. 
+    /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at specified delimiters of type <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/></typeparam>  
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitAnyEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
         readonly ReadOnlySpan<T> Delimiters;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitAnyEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.SplitAny{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/> with the instances of <typeparamref name="T"/> that delimit the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
         public SpanSplitAnyEnumerator(ReadOnlySpan<T> source, ReadOnlySpan<T> delimiters)
         {
             Span = source;
             Delimiters = delimiters;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitAnyEnumerator<T> GetEnumerator()
         {
             return this;
@@ -32,7 +38,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.
+    /// </summary>
     public ref struct SpanSplitAnyStringSplitOptionsEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -12,10 +12,16 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitAnyStringSplitOptionsEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.SplitAny(ReadOnlySpan{char}, ReadOnlySpan{char}, StringSplitOptions)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/> with the <see cref="char"/> elements that delimit the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         public SpanSplitAnyStringSplitOptionsEnumerator(ReadOnlySpan<char> source, ReadOnlySpan<char> delimiters, StringSplitOptions options)
         {
             Span = source;
@@ -23,7 +29,8 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitAnyStringSplitOptionsEnumerator GetEnumerator()
         {
             return this;
@@ -32,7 +39,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsWithCountEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.
+    /// </summary>
     public ref struct SpanSplitAnyStringSplitOptionsWithCountEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -14,10 +14,17 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitAnyStringSplitOptionsWithCountEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.SplitAny(ReadOnlySpan{char}, ReadOnlySpan{char}, StringSplitOptions)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/> with the <see cref="char"/> elements that delimit the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitAnyStringSplitOptionsWithCountEnumerator(ReadOnlySpan<char> source, ReadOnlySpan<char> delimiters, StringSplitOptions options, int count)
         {
             Span = source;
@@ -27,7 +34,8 @@ namespace SpanExtensions.Enumerators
             Current = default;
             currentCount = 0;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitAnyStringSplitOptionsWithCountEnumerator GetEnumerator()
         {
             return this;
@@ -36,7 +44,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/SplitAny/SpanSplitAnyWithCountEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyWithCountEnumerator.cs
@@ -3,9 +3,9 @@
 namespace SpanExtensions.Enumerators
 {
     /// <summary>
-    /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at specified delimiters of type <typeparamref name="T"/> with an upper limit of splits performed.  
+    /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at specified delimiters of type <typeparamref name="T"/> with an upper limit of splits performed.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/></typeparam>  
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitAnyWithCountEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
@@ -14,10 +14,16 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
-        
+
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitAnyEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.SplitAny{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/> with the instances of <typeparamref name="T"/> that delimit the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitAnyWithCountEnumerator(ReadOnlySpan<T> source, ReadOnlySpan<T> delimiters, int count)
         {
             Span = source;
@@ -25,7 +31,9 @@ namespace SpanExtensions.Enumerators
             Count = count;
             Current = default;
             currentCount = 0;
-        }/// <summary></summary>
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitAnyWithCountEnumerator<T> GetEnumerator()
         {
             return this;
@@ -34,7 +42,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceEnumerator.cs
@@ -2,26 +2,33 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at specified delimiters and based on specified <see cref="StringSplitOptions"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitSequenceEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
         readonly ReadOnlySpan<T> Delimiter;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitSequenceEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
         public SpanSplitSequenceEnumerator(ReadOnlySpan<T> source, ReadOnlySpan<T> delimiter)
         {
             Span = source;
             Delimiter = delimiter;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitSequenceEnumerator<T> GetEnumerator()
         {
             return this;
@@ -30,7 +37,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>.
+    /// </summary>
     public ref struct SpanSplitSequenceStringSplitOptionsEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -12,10 +12,16 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitSequenceStringSplitOptionsEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split(ReadOnlySpan{char}, ReadOnlySpan{char}, StringSplitOptions)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         public SpanSplitSequenceStringSplitOptionsEnumerator(ReadOnlySpan<char> source, ReadOnlySpan<char> delimiter, StringSplitOptions options)
         {
             Span = source;
@@ -23,7 +29,8 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitSequenceStringSplitOptionsEnumerator GetEnumerator()
         {
             return this;
@@ -32,7 +39,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsWithCountEnumerator.cs
@@ -2,9 +2,9 @@
 
 namespace SpanExtensions.Enumerators
 {
-    /// <summary> 
-    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>  with an upper limit of splits performed.  
-    /// </summary>   
+    /// <summary>
+    /// Supports iteration over a <see cref="ReadOnlySpan{Char}"/> by splitting it at a specified delimiter and based on specified <see cref="StringSplitOptions"/>  with an upper limit of splits performed.
+    /// </summary>
     public ref struct SpanSplitSequenceStringSplitOptionsWithCountEnumerator
     {
         ReadOnlySpan<char> Span;
@@ -14,10 +14,17 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<char> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitSequenceStringSplitOptionsWithCountEnumerator"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split(ReadOnlySpan{char}, ReadOnlySpan{char}, StringSplitOptions)"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitSequenceStringSplitOptionsWithCountEnumerator(ReadOnlySpan<char> source, ReadOnlySpan<char> delimiter, StringSplitOptions options, int count)
         {
             Span = source;
@@ -27,7 +34,8 @@ namespace SpanExtensions.Enumerators
             Current = default;
             currentCount = 0;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitSequenceStringSplitOptionsWithCountEnumerator GetEnumerator()
         {
             return this;
@@ -36,7 +44,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<char> span = Span;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceWithCountEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceWithCountEnumerator.cs
@@ -5,7 +5,7 @@ namespace SpanExtensions.Enumerators
     /// <summary>
     /// Supports iteration over a <see cref="ReadOnlySpan{T}"/> by splitting it at a specified delimiter of type <typeparamref name="T"/> with an upper limit of splits performed.
     /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/></typeparam>
+    /// <typeparam name="T">The type of elements in the enumerated <see cref="ReadOnlySpan{T}"/>.</typeparam>
     public ref struct SpanSplitSequenceWithCountEnumerator<T> where T : IEquatable<T>
     {
         ReadOnlySpan<T> Span;
@@ -14,10 +14,16 @@ namespace SpanExtensions.Enumerators
         int currentCount;
 
         /// <summary>
-        /// Gets the element in the collection at the current position of the enumerator. 
+        /// Gets the element in the collection at the current position of the enumerator.
         /// </summary>
         public ReadOnlySpan<T> Current { get; internal set; }
 
+        /// <summary>
+        /// Constructs a <see cref="SpanSplitSequenceWithCountEnumerator{T}"/> from a span and a delimiter. <strong>Only consume this class through <see cref="ReadOnlySpanExtensions.Split{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/></strong>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="source"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         public SpanSplitSequenceWithCountEnumerator(ReadOnlySpan<T> source, ReadOnlySpan<T> delimiter, int count)
         {
             Span = source;
@@ -26,7 +32,8 @@ namespace SpanExtensions.Enumerators
             Current = default;
             currentCount = 0;
         }
-        /// <summary></summary>
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
         public readonly SpanSplitSequenceWithCountEnumerator<T> GetEnumerator()
         {
             return this;
@@ -35,7 +42,7 @@ namespace SpanExtensions.Enumerators
         /// <summary>
         /// Advances the enumerator to the next element of the collection.
         /// </summary>
-        /// <returns><code>true</code> if the enumerator was successfully advanced to the next element; <code>false</code> if the enumerator has passed the end of the collection.</returns>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
             ReadOnlySpan<T> span = Span;

--- a/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.Linq.cs
+++ b/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.Linq.cs
@@ -4,18 +4,17 @@ using System.Numerics;
 namespace SpanExtensions
 {
     /// <summary>
-    /// Extension Methods for <see cref="ReadOnlySpan{T}"/>  
+    /// Extension Methods for <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     public static partial class ReadOnlySpanExtensions
     {
-
         /// <summary>
         /// Determines whether all elements in <paramref name="source"/> satisfy a condition.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
         /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
-        /// <param name="predicate">The condition to be satisfied.</param>   
-        /// <returns>A <see cref="bool"/> indicating whether or not every element in <paramref name="source"/> satisified the condition.</returns> 
+        /// <param name="predicate">The condition to be satisfied.</param>
+        /// <returns>A <see cref="bool"/> indicating whether or not every element in <paramref name="source"/> satisified the condition.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static bool All<T>(this ReadOnlySpan<T> source, Predicate<T> predicate) where T : IEquatable<T>
         {
@@ -30,12 +29,12 @@ namespace SpanExtensions
         }
 
         /// <summary>
-        /// Determines whether any element in <paramref name="source"/> satisfies a condition. 
-        /// </summary>  
-        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>   
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>    
-        /// <param name="predicate">The condition to be satisfied.</param>  
-        /// <returns>A <see cref="bool"/> indicating whether or not any elements satisified the condition.</returns> 
+        /// Determines whether any element in <paramref name="source"/> satisfies a condition.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
+        /// <param name="predicate">The condition to be satisfied.</param>
+        /// <returns>A <see cref="bool"/> indicating whether or not any elements satisified the condition.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static bool Any<T>(this ReadOnlySpan<T> source, Predicate<T> predicate) where T : IEquatable<T>
         {
@@ -54,7 +53,7 @@ namespace SpanExtensions
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
         /// <returns>The Sum of all the <typeparamref name="T"/>s in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static T Sum<T>(this ReadOnlySpan<T> source) where T : INumber<T>
@@ -70,7 +69,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Byte}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Byte}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte Sum(this ReadOnlySpan<byte> source)
@@ -86,7 +85,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{UInt16}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt16}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ushort Sum(this ReadOnlySpan<ushort> source)
@@ -102,7 +101,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{UInt32}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt32}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static uint Sum(this ReadOnlySpan<uint> source)
@@ -118,7 +117,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{UInt64}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt64}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ulong Sum(this ReadOnlySpan<ulong> source)
@@ -134,7 +133,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{SByte}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{SByte}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static sbyte Sum(this ReadOnlySpan<sbyte> source)
@@ -150,7 +149,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Int16}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Int16}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static short Sum(this ReadOnlySpan<short> source)
@@ -166,7 +165,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Int32}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Int32}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static int Sum(this ReadOnlySpan<int> source)
@@ -182,7 +181,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static long Sum(this ReadOnlySpan<long> source)
@@ -198,7 +197,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Single}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Single}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static float Sum(this ReadOnlySpan<float> source)
@@ -214,7 +213,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Double}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Double}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static double Sum(this ReadOnlySpan<double> source)
@@ -230,7 +229,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Decimal}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Decimal}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static decimal Sum(this ReadOnlySpan<decimal> source)
@@ -246,7 +245,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{BigInteger}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{BigInteger}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static BigInteger Sum(this ReadOnlySpan<BigInteger> source)
@@ -265,7 +264,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlySpan{Half}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="ReadOnlySpan{Half}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static Half Sum(this ReadOnlySpan<Half> source)
@@ -279,7 +278,7 @@ namespace SpanExtensions
         }
 #endif
 
-        /// <summary> 
+        /// <summary>
         /// Bypasses a specified number of elements in <paramref name="source"/> and then returns the remaining elements.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
@@ -292,7 +291,7 @@ namespace SpanExtensions
             return source[count..];
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a specified number of contiguous elements from the start of a <see cref="ReadOnlySpan{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
@@ -305,12 +304,12 @@ namespace SpanExtensions
             return source[..count];
         }
 
-        /// <summary> 
+        /// <summary>
         /// Bypasses elements in <paramref name="source"/> as long as a <paramref name="condition"/> is true and then returns the remaining elements. The element's index is used in the logic of the predicate function.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
         /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
-        /// <param name="condition">A function to test each element for a condition.</param> 
+        /// <param name="condition">A function to test each element for a condition.</param>
         /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains the elements from <paramref name="source"/> starting at the first element in the linear series that does not pass the specified <paramref name="condition" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="condition"/> is null.</exception>
         public static ReadOnlySpan<T> SkipWhile<T>(this ReadOnlySpan<T> source, Predicate<T> condition)
@@ -323,18 +322,18 @@ namespace SpanExtensions
                 {
                     return source.Skip(count);
                 }
-                count++;  
-            }  
-            return ReadOnlySpan<T>.Empty; 
+                count++;
+            }
+            return ReadOnlySpan<T>.Empty;
         }
 
-        ///  <summary> 
-        /// Returns elements from <paramref name="source"/> as long as a specified <paramref name="condition"/> is true, and then skips the remaining elements.   
-        /// </summary> 
-        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam> 
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>  
-        /// <param name="condition">A function to test each element for a condition.</param>    
-        /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains elements from <paramref name="source"/> that occur before the element at which the <paramref name="condition"/> no longer passes.</returns> 
+        ///  <summary>
+        /// Returns elements from <paramref name="source"/> as long as a specified <paramref name="condition"/> is true, and then skips the remaining elements.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
+        /// <param name="condition">A function to test each element for a condition.</param>
+        /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains elements from <paramref name="source"/> that occur before the element at which the <paramref name="condition"/> no longer passes.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="condition"/> is null.</exception>
         public static ReadOnlySpan<T> TakeWhile<T>(this ReadOnlySpan<T> source, Predicate<T> condition)
         {
@@ -351,7 +350,7 @@ namespace SpanExtensions
             return ReadOnlySpan<T>.Empty;
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a new <see cref="ReadOnlySpan{T}"/> that contains the elements from source with the last <paramref name="count"/> elements of the source collection omitted.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
@@ -369,13 +368,13 @@ namespace SpanExtensions
             return source[..(source.Length - count)];
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a new <see cref="ReadOnlySpan{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>.
         /// </summary>
-        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam> 
+        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
         /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
         /// <param name="count">The number of elements to take from the end of <paramref name="source"/>.</param>
-        /// <returns>A new <see cref="ReadOnlySpan{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>. </returns>
+        /// <returns>A new <see cref="ReadOnlySpan{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>.</returns>
         /// <remarks>If <paramref name="count"/> is not a positive number, this method returns <see cref="ReadOnlySpan{T}.Empty"/>.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ReadOnlySpan<T> TakeLast<T>(this ReadOnlySpan<T> source, int count)
@@ -389,11 +388,11 @@ namespace SpanExtensions
 
 #if NET7_0_OR_GREATER
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam> 
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static T Average<T>(this ReadOnlySpan<T> source) where T : INumber<T>
@@ -405,10 +404,10 @@ namespace SpanExtensions
 
 #if NET5_0_OR_GREATER
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Half}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Half}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static Half Average(this ReadOnlySpan<Half> source)
@@ -417,10 +416,10 @@ namespace SpanExtensions
             return (Half)((float)sum / source.Length);
         }
 #endif
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Byte}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Byte}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte Average(this ReadOnlySpan<byte> source)
@@ -429,10 +428,10 @@ namespace SpanExtensions
             return (byte)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{UInt16}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt16}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ushort Average(this ReadOnlySpan<ushort> source)
@@ -441,10 +440,10 @@ namespace SpanExtensions
             return (ushort)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{uint32}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{uint32}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static uint Average(this ReadOnlySpan<uint> source)
@@ -453,10 +452,10 @@ namespace SpanExtensions
             return (uint)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{UInt64}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{UInt64}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ulong Average(this ReadOnlySpan<ulong> source)
@@ -465,10 +464,10 @@ namespace SpanExtensions
             return sum / (ulong)source.Length;
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{SByte}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{SByte}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static sbyte Average(this ReadOnlySpan<sbyte> source)
@@ -477,10 +476,10 @@ namespace SpanExtensions
             return (sbyte)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Int16}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Int16}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static short Average(this ReadOnlySpan<short> source)
@@ -489,10 +488,10 @@ namespace SpanExtensions
             return (short)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Int32}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Int32}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static int Average(this ReadOnlySpan<int> source)
@@ -501,10 +500,10 @@ namespace SpanExtensions
             return sum / source.Length;
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static long Average(this ReadOnlySpan<long> source)
@@ -513,10 +512,10 @@ namespace SpanExtensions
             return (sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Single}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Single}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static float Average(this ReadOnlySpan<float> source)
@@ -525,10 +524,10 @@ namespace SpanExtensions
             return (float)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Double}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Double}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static double Average(this ReadOnlySpan<double> source)
@@ -537,10 +536,10 @@ namespace SpanExtensions
             return (double)(sum / source.Length);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{Int64}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static decimal Average(this ReadOnlySpan<decimal> source)
@@ -549,10 +548,10 @@ namespace SpanExtensions
             return sum / source.Length;
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="ReadOnlySpan{BigInteger}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadOnlySpan{BigInteger}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static BigInteger Average(this ReadOnlySpan<BigInteger> source)

--- a/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.Split.cs
+++ b/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.Split.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections;
-using SpanExtensions.Enumerators; 
+using SpanExtensions.Enumerators;
 
 namespace SpanExtensions
 {
+    /// <summary>
+    /// Extension Methods for <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
     public static partial class ReadOnlySpanExtensions
     {
         /// <summary>
@@ -11,7 +14,7 @@ namespace SpanExtensions
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
         /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
-        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitEnumerator<T> Split<T>(this ReadOnlySpan<T> span, T delimiter) where T : IEquatable<T>
         {
@@ -22,9 +25,9 @@ namespace SpanExtensions
         /// Splits a <see cref="ReadOnlySpan{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/></param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitWithCountEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitWithCountEnumerator<T> Split<T>(this ReadOnlySpan<T> span, T delimiter, int count) where T : IEquatable<T>
         {
@@ -33,9 +36,9 @@ namespace SpanExtensions
 
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{Char}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>.
-        /// </summary> 
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>
-        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/></param>
+        /// </summary>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitStringSplitOptionsEnumerator Split(this ReadOnlySpan<char> span, char delimiter, StringSplitOptions options)
@@ -44,24 +47,24 @@ namespace SpanExtensions
         }
 
         /// <summary>
-        /// Splits a <see cref="ReadOnlySpan{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>. 
-        /// </summary>  
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>  
-        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/></param>  
-        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>  
-        /// <param name="count">the maximum number of results</param>
+        /// Splits a <see cref="ReadOnlySpan{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitStringSplitOptionsWithCountEnumerator Split(this ReadOnlySpan<char> span, char delimiter, StringSplitOptions options, int count)
         {
             return new SpanSplitStringSplitOptionsWithCountEnumerator(span, delimiter, options, count);
         }
 
-        /// <summary>  
+        /// <summary>
         /// Splits a <see cref="ReadOnlySpan{T}"/> into multiple ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/> with the instances of <typeparamref name="T"/> that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyEnumerator<T> SplitAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> delimiters) where T : IEquatable<T>
         {
@@ -72,9 +75,9 @@ namespace SpanExtensions
         /// Splits a <see cref="ReadOnlySpan{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the any of the specified  <paramref name="delimiters"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/> with the instances of <typeparamref name="T"/> that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyWithCountEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyWithCountEnumerator<T> SplitAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> delimiters, int count) where T : IEquatable<T>
         {
@@ -84,8 +87,8 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{Char}"/> into multiple ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyStringSplitOptionsEnumerator SplitAny(this ReadOnlySpan<char> span, ReadOnlySpan<char> delimiters, StringSplitOptions options)
@@ -96,10 +99,10 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyStringSplitOptionsWithCountEnumerator SplitAny(this ReadOnlySpan<char> span, ReadOnlySpan<char> delimiters, StringSplitOptions options, int count)
         {
@@ -108,10 +111,10 @@ namespace SpanExtensions
 
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{T}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/>.
-        /// </summary> 
+        /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/></param>
+        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceEnumerator<T> Split<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> delimiter) where T : IEquatable<T>
         {
@@ -122,9 +125,9 @@ namespace SpanExtensions
         /// Splits a <see cref="ReadOnlySpan{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/></param>
-        /// <param name="count">the maximum number of results</param> 
+        /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct , which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceWithCountEnumerator<T> Split<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> delimiter, int count) where T : IEquatable<T>
         {
@@ -134,8 +137,8 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{Char}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/></param>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceStringSplitOptionsEnumerator Split(this ReadOnlySpan<char> span, ReadOnlySpan<char> delimiter, StringSplitOptions options)
@@ -146,10 +149,10 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="ReadOnlySpan{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
-        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/></param>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
-        /// /// <param name="count">the maximum number of results</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceStringSplitOptionsWithCountEnumerator Split(this ReadOnlySpan<char> span, ReadOnlySpan<char> delimiter, StringSplitOptions options, int count)
         {

--- a/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.String.cs
+++ b/src/Extensions/ReadOnlySpan/ReadOnlySpanExtensions.String.cs
@@ -3,16 +3,18 @@ using System;
 
 namespace SpanExtensions
 {
+    /// <summary>
+    /// Extension Methods for <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
     public static partial class ReadOnlySpanExtensions
     {
-
         /// <summary>
         /// Returns a new <see cref="ReadOnlySpan{T}"/> in which all the characters in the current instance, beginning at <paramref name="startIndex"/> and continuing through the last position, have been deleted.
         /// </summary>
-        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam> 
+        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
         /// <param name="startIndex">The zero-based position to begin deleting characters.</param>
-        /// <returns>A new  <see cref="ReadOnlySpan{T}"/> that is equivalent to this <see cref="ReadOnlySpan{T}"/> except for thse removed characters.</returns>  
+        /// <returns>A new <see cref="ReadOnlySpan{T}"/> that is equivalent to <paramref name="source"/> except for thse removed characters.</returns>
         public static ReadOnlySpan<T> Remove<T>(this ReadOnlySpan<T> source, int startIndex)
         {
             return source[..startIndex];

--- a/src/Extensions/Span/SpanExtensions.Linq.cs
+++ b/src/Extensions/Span/SpanExtensions.Linq.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 namespace SpanExtensions
 {
     /// <summary>
-    /// Extension Methods for <see cref="Span{T}"/>  
+    /// Extension Methods for <see cref="Span{T}"/>.
     /// </summary>
     public static partial class SpanExtensions
     {
@@ -14,8 +14,8 @@ namespace SpanExtensions
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
         /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
-        /// <param name="predicate">The Condition to be satisfied.</param>   
-        /// <returns>A <see cref="bool"/> indicating whether or not every element in <paramref name="source"/> satisified the condition.</returns> 
+        /// <param name="predicate">The Condition to be satisfied.</param>
+        /// <returns>A <see cref="bool"/> indicating whether or not every element in <paramref name="source"/> satisified the condition.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static bool All<T>(this Span<T> source, Predicate<T> predicate) where T : IEquatable<T>
         {
@@ -23,12 +23,12 @@ namespace SpanExtensions
         }
 
         /// <summary>
-        /// Determines whether any element in <paramref name="source"/> satisfies a condition. 
-        /// </summary>  
-        /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>   
-        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>    
-        /// <param name="predicate">The Condition to be satisfied.</param>  
-        /// <returns>A <see cref="bool"/> indicating whether or not any elements satisified the condition.</returns> 
+        /// Determines whether any element in <paramref name="source"/> satisfies a condition.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
+        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
+        /// <param name="predicate">The Condition to be satisfied.</param>
+        /// <returns>A <see cref="bool"/> indicating whether or not any elements satisified the condition.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         public static bool Any<T>(this Span<T> source, Predicate<T> predicate) where T : IEquatable<T>
         {
@@ -41,7 +41,7 @@ namespace SpanExtensions
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
-        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
         /// <returns>The Sum of all the <typeparamref name="T"/>s in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static T Sum<T>(this Span<T> source) where T : INumber<T>
@@ -52,7 +52,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Byte}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Byte}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte Sum(this Span<byte> source)
@@ -63,7 +63,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{UInt16}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{UInt16}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ushort Sum(this Span<ushort> source)
@@ -74,7 +74,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{UInt32}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{UInt32}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static uint Sum(this Span<uint> source)
@@ -84,7 +84,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{UInt64}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{UInt64}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ulong Sum(this Span<ulong> source)
@@ -95,7 +95,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{SByte}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{SByte}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static sbyte Sum(this Span<sbyte> source)
@@ -106,7 +106,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Int16}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Int16}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static short Sum(this Span<short> source)
@@ -117,7 +117,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Int32}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Int32}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static int Sum(this Span<int> source)
@@ -128,7 +128,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Int64}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Int64}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static long Sum(this Span<long> source)
@@ -139,7 +139,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Single}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Single}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static float Sum(this Span<float> source)
@@ -150,7 +150,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Double}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Double}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static double Sum(this Span<double> source)
@@ -161,7 +161,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Decimal}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Decimal}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static decimal Sum(this Span<decimal> source)
@@ -172,7 +172,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{BigInteger}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{BigInteger}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static BigInteger Sum(this Span<BigInteger> source)
@@ -186,7 +186,7 @@ namespace SpanExtensions
         /// <summary>
         /// Computes the Sum of all the elements in <paramref name="source"/>.
         /// </summary>
-        /// <param name="source">The <see cref="Span{Half}"/> to operate on.</param> 
+        /// <param name="source">The <see cref="Span{Half}"/> to operate on.</param>
         /// <returns>The Sum of all the elements in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static Half Sum(this Span<Half> source)
@@ -195,7 +195,7 @@ namespace SpanExtensions
         }
 #endif
 
-        /// <summary> 
+        /// <summary>
         /// Bypasses a specified number of elements in <paramref name="source"/> and then returns the remaining elements.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
@@ -208,24 +208,24 @@ namespace SpanExtensions
             return source[count..];
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a specified number of contiguous elements from the start of a <see cref="Span{T}"/>.
-        /// </summary> 
+        /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
-        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>  
-        /// <param name="count">The Number of elements to take.</param> 
-        /// <returns>A <see cref="Span{T}"/> that contains <paramref name="count"/> elements from the start of the input sequence</returns>
+        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
+        /// <param name="count">The Number of elements to take.</param>
+        /// <returns>A <see cref="Span{T}"/> that contains <paramref name="count"/> elements from the start of the input sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static Span<T> Take<T>(this Span<T> source, int count)
         {
             return source[..count];
         }
-        /// <summary> 
+        /// <summary>
         /// Bypasses elements in <paramref name="source"/> as long as a <paramref name="condition"/> is true and then returns the remaining elements. The element's index is used in the logic of the predicate function.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
         /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
-        /// <param name="condition">A function to test each element for a condition.</param> 
+        /// <param name="condition">A function to test each element for a condition.</param>
         /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains the elements from <paramref name="source"/> starting at the first element in the linear series that does not pass the specified <paramref name="condition" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="condition"/> is null.</exception>
         public static Span<T> SkipWhile<T>(this Span<T> source, Predicate<T> condition)
@@ -243,13 +243,13 @@ namespace SpanExtensions
             return Span<T>.Empty;
         }
 
-        ///  <summary> 
-        /// Returns elements from <paramref name="source"/> as long as a specified <paramref name="condition"/> is true, and then skips the remaining elements.   
-        /// </summary> 
-        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam> 
-        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>  
-        /// <param name="condition">A function to test each element for a condition.</param>    
-        /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains elements from <paramref name="source"/> that occur before the element at which the <paramref name="condition"/> no longer passes.</returns> 
+        ///  <summary>
+        /// Returns elements from <paramref name="source"/> as long as a specified <paramref name="condition"/> is true, and then skips the remaining elements.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
+        /// <param name="source">The <see cref="ReadOnlySpan{T}"/> to operate on.</param>
+        /// <param name="condition">A function to test each element for a condition.</param>
+        /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains elements from <paramref name="source"/> that occur before the element at which the <paramref name="condition"/> no longer passes.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="condition"/> is null.</exception>
         public static Span<T> TakeWhile<T>(this Span<T> source, Predicate<T> condition)
         {
@@ -266,7 +266,7 @@ namespace SpanExtensions
             return Span<T>.Empty;
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a new <see cref="Span{T}"/> that contains the elements from source with the last <paramref name="count"/> elements of the source collection omitted.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
@@ -283,13 +283,13 @@ namespace SpanExtensions
             return source[..(source.Length - count)];
         }
 
-        /// <summary> 
+        /// <summary>
         /// Returns a new <see cref="Span{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>.
         /// </summary>
-        /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam> 
+        /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
         /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
         /// <param name="count">The number of elements to take from the end of <paramref name="source"/>.</param>
-        /// <returns>A new <see cref="Span{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>. </returns>
+        /// <returns>A new <see cref="Span{T}"/> that contains the last <paramref name="count"/> elements from <paramref name="source"/>.</returns>
         /// <remarks>If <paramref name="count"/> is not a positive number, this method returns <see cref="Span{T}.Empty"/>.</remarks>
         public static Span<T> TakeLast<T>(this Span<T> source, int count)
         {
@@ -302,11 +302,11 @@ namespace SpanExtensions
 
 #if NET7_0_OR_GREATER
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam> 
-        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
+        /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static T Average<T>(this Span<T> source) where T : INumber<T>
@@ -318,10 +318,10 @@ namespace SpanExtensions
 
 #if NET5_0_OR_GREATER
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Half}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Half}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static Half Average(this Span<Half> source)
@@ -329,10 +329,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 #endif
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Byte}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Byte}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte Average(this Span<byte> source)
@@ -340,10 +340,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{UInt16}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{UInt16}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ushort Average(this Span<ushort> source)
@@ -351,20 +351,20 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{uint32}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{uint32}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static uint Average(this Span<uint> source)
         {
             return ReadOnlySpanExtensions.Average(source);
         }
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{UInt64}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{UInt64}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static ulong Average(this Span<ulong> source)
@@ -372,10 +372,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{SByte}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{SByte}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static sbyte Average(this Span<sbyte> source)
@@ -383,10 +383,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Int16}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Int16}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static short Average(this Span<short> source)
@@ -394,10 +394,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Int32}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Int32}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static int Average(this Span<int> source)
@@ -405,10 +405,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Int64}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Int64}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static long Average(this Span<long> source)
@@ -416,10 +416,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Single}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Single}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static float Average(this Span<float> source)
@@ -427,10 +427,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Double}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Double}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static double Average(this Span<double> source)
@@ -438,10 +438,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{Decimal}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{Decimal}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static decimal Average(this Span<decimal> source)
@@ -449,10 +449,10 @@ namespace SpanExtensions
             return ReadOnlySpanExtensions.Average(source);
         }
 
-        /// <summary> 
-        /// Computes the Average of all the values in <paramref name="source"/>. 
-        /// </summary>  
-        /// <param name="source">The <see cref="Span{BigInteger}"/> to operate on.</param>    
+        /// <summary>
+        /// Computes the Average of all the values in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Span{BigInteger}"/> to operate on.</param>
         /// <returns>The Average of all the values in <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static BigInteger Average(this Span<BigInteger> source)

--- a/src/Extensions/Span/SpanExtensions.Split.cs
+++ b/src/Extensions/Span/SpanExtensions.Split.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections;
-using SpanExtensions.Enumerators; 
+using SpanExtensions.Enumerators;
 
 namespace SpanExtensions
 {
+    /// <summary>
+    /// Extension Methods for <see cref="Span{T}"/>.
+    /// </summary>
     public static partial class SpanExtensions
     {
         /// <summary>
@@ -11,7 +14,7 @@ namespace SpanExtensions
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
         /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
-        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in the <see cref="Span{T}"/></param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitEnumerator<T> Split<T>(this Span<T> span, T delimiter) where T : IEquatable<T>
         {
@@ -22,9 +25,9 @@ namespace SpanExtensions
         /// Splits a <see cref="Span{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="Span{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in the <see cref="Span{T}"/></param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <typeparamref name="T"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitWithCountEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitWithCountEnumerator<T> Split<T>(this Span<T> span, T delimiter, int count) where T : IEquatable<T>
         {
@@ -33,9 +36,9 @@ namespace SpanExtensions
 
         /// <summary>
         /// Splits a <see cref="Span{Char}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>.
-        /// </summary> 
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>
-        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in the <see cref="Span{Char}"/></param>
+        /// </summary>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitStringSplitOptionsEnumerator Split(this Span<char> span, char delimiter, StringSplitOptions options)
@@ -44,24 +47,24 @@ namespace SpanExtensions
         }
 
         /// <summary>
-        /// Splits a <see cref="Span{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>. 
-        /// </summary>  
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>  
-        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in the <see cref="Span{Char}"/></param>  
-        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>  
-        /// <param name="count">the maximum number of results</param>
+        /// Splits a <see cref="Span{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/> and the specified <paramref name="options"/>.
+        /// </summary>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiter">A <see cref="char"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitStringSplitOptionsWithCountEnumerator Split(this Span<char> span, char delimiter, StringSplitOptions options, int count)
         {
             return new SpanSplitStringSplitOptionsWithCountEnumerator(span, delimiter, options, count);
         }
 
-        /// <summary>  
+        /// <summary>
         /// Splits a <see cref="Span{T}"/> into multiple ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="Span{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="Span{T}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
+        /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyEnumerator<T> SplitAny<T>(this Span<T> span, ReadOnlySpan<T> delimiters) where T : IEquatable<T>
         {
@@ -72,9 +75,9 @@ namespace SpanExtensions
         /// Splits a <see cref="Span{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the any of the specified  <paramref name="delimiters"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="Span{T}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{T}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyWithCountEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyWithCountEnumerator<T> SplitAny<T>(this Span<T> span, ReadOnlySpan<T> delimiters, int count) where T : IEquatable<T>
         {
@@ -84,8 +87,8 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="Span{Char}"/> into multiple ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyStringSplitOptionsEnumerator SplitAny(this Span<char> span, ReadOnlySpan<char> delimiters, StringSplitOptions options)
@@ -96,10 +99,10 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="Span{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the any of the specified <paramref name="delimiters"/>.
         /// </summary>
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>
-        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiters">A <see cref="ReadOnlySpan{Char}"/>, that delimit the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
-        /// <param name="count">the maximum number of results</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitAnyStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitAnyStringSplitOptionsWithCountEnumerator SplitAny(this Span<char> span, ReadOnlySpan<char> delimiters, StringSplitOptions options, int count)
         {
@@ -108,10 +111,10 @@ namespace SpanExtensions
 
         /// <summary>
         /// Splits a <see cref="Span{T}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/>.
-        /// </summary> 
+        /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="Span{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/></param>
+        /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceEnumerator{T}"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceEnumerator<T> Split<T>(this Span<T> span, ReadOnlySpan<T> delimiter) where T : IEquatable<T>
         {
@@ -122,9 +125,9 @@ namespace SpanExtensions
         /// Splits a <see cref="Span{T}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the <see cref="ReadOnlySpan{T}"/>.</typeparam>
-        /// <param name="span">The <see cref="Span{T}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{T}"/></param>
-        /// <param name="count">the maximum number of results</param> 
+        /// <param name="span">The <see cref="Span{T}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{T}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
+        /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct , which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceWithCountEnumerator<T> Split<T>(this Span<T> span, ReadOnlySpan<T> delimiter, int count) where T : IEquatable<T>
         {
@@ -134,8 +137,8 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="Span{Char}"/> into multiple ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in the <see cref="ReadOnlySpan{Char}"/></param>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-ReadOnlySpans in <paramref name="span"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceStringSplitOptionsEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceStringSplitOptionsEnumerator Split(this Span<char> span, ReadOnlySpan<char> delimiter, StringSplitOptions options)
@@ -146,10 +149,10 @@ namespace SpanExtensions
         /// <summary>
         /// Splits a <see cref="Span{Char}"/> into at most <paramref name="count"/> ReadOnlySpans based on the specified <paramref name="delimiter"/>.
         /// </summary>
-        /// <param name="span">The <see cref="Span{Char}"/> to be split</param>
-        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-Spans in the <see cref="ReadOnlySpan{Char}"/></param>
+        /// <param name="span">The <see cref="Span{Char}"/> to be split.</param>
+        /// <param name="delimiter">An instance of <see cref="ReadOnlySpan{Char}"/> that delimits the various sub-Spans in the <see cref="ReadOnlySpan{Char}"/>.</param>
         /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim results and include empty results.</param>
-        /// /// <param name="count">the maximum number of results</param>
+        /// /// <param name="count">The maximum number of sub-ReadOnlySpans to split into.</param>
         /// <returns>An instance of the ref struct <see cref="SpanSplitSequenceStringSplitOptionsWithCountEnumerator"/>, which works the same way as every <see cref="IEnumerator"/> does and can be used in a foreach construct.</returns>
         public static SpanSplitSequenceStringSplitOptionsWithCountEnumerator Split(this Span<char> span, ReadOnlySpan<char> delimiter, StringSplitOptions options, int count)
         {

--- a/src/Extensions/Span/SpanExtensions.String.cs
+++ b/src/Extensions/Span/SpanExtensions.String.cs
@@ -2,16 +2,18 @@
 
 namespace SpanExtensions
 {
+    /// <summary>
+    /// Extension Methods for <see cref="Span{T}"/>.
+    /// </summary>
     public static partial class SpanExtensions
     {
-
         /// <summary>
         /// Returns a new <see cref="Span{T}"/> in which all the characters in the current instance, beginning at <paramref name="startIndex"/> and continuing through the last position, have been deleted.
         /// </summary>
-        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam> 
+        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The <see cref="Span{T}"/> to operate on.</param>
         /// <param name="startIndex">The zero-based position to begin deleting characters.</param>
-        /// <returns>A new <see cref="Span{T}"/> that is equivalent to this <see cref="Span{T}"/> except for the removed characters.</returns>  
+        /// <returns>A new <see cref="Span{T}"/> that is equivalent to <paramref name="source"/> except for the removed characters.</returns>
         public static Span<T> Remove<T>(this Span<T> source, int startIndex)
         {
             return source[..startIndex];


### PR DESCRIPTION
- removed extra white spaces and lines
- fixed incorrect type references
- changed boolean code blocks to see-langword tags
- added missing doc-comments
- changed some type references to parameter references to remove ambiguity
- added missing punctuations
- reworded some comments to closer match examples in the .NET documentation
- fixed some comments