### PR TITLE
Fixed empty spans dropped at the end of enumeration

### DIFF
--- a/src/Enumerators/Split/SpanSplitEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitEnumerator.cs
@@ -10,6 +10,7 @@ namespace SpanExtensions.Enumerators
     {
         ReadOnlySpan<T> Span;
         readonly T Delimiter;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -26,6 +27,7 @@ namespace SpanExtensions.Enumerators
             Span = source;
             Delimiter = delimiter;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -42,16 +44,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             int index = span.IndexOf(Delimiter);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }

--- a/src/Enumerators/Split/SpanSplitStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitStringSplitOptionsEnumerator.cs
@@ -10,6 +10,7 @@ namespace SpanExtensions.Enumerators
         ReadOnlySpan<char> Span;
         readonly char Delimiter;
         readonly StringSplitOptions Options;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -28,6 +29,7 @@ namespace SpanExtensions.Enumerators
             Delimiter = delimiter;
             Options = options;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -44,16 +46,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             int index = span.IndexOf(Delimiter);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -69,8 +72,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + 1)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + 1)..];
             return true;

--- a/src/Enumerators/Split/SpanSplitStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitStringSplitOptionsWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -33,6 +34,7 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -49,11 +51,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -62,7 +65,7 @@ namespace SpanExtensions.Enumerators
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -80,8 +83,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + 1)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + 1)..];
             return true;

--- a/src/Enumerators/Split/SpanSplitWithCountEnumerator.cs
+++ b/src/Enumerators/Split/SpanSplitWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly T Delimiter;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -31,6 +32,7 @@ namespace SpanExtensions.Enumerators
             Count = count;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -47,11 +49,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -59,7 +62,7 @@ namespace SpanExtensions.Enumerators
             int index = span.IndexOf(Delimiter);
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }

--- a/src/Enumerators/SplitAny/SpanSplitAnyEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyEnumerator.cs
@@ -11,6 +11,7 @@ namespace SpanExtensions.Enumerators
     {
         ReadOnlySpan<T> Span;
         readonly ReadOnlySpan<T> Delimiters;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -27,6 +28,7 @@ namespace SpanExtensions.Enumerators
             Span = source;
             Delimiters = delimiters;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -43,16 +45,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             int index = span.IndexOfAny(Delimiters);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }

--- a/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsEnumerator.cs
@@ -10,6 +10,7 @@ namespace SpanExtensions.Enumerators
         ReadOnlySpan<char> Span;
         readonly ReadOnlySpan<char> Delimiters;
         readonly StringSplitOptions Options;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -28,6 +29,7 @@ namespace SpanExtensions.Enumerators
             Delimiters = delimiters;
             Options = options;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -44,16 +46,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             int index = span.IndexOfAny(Delimiters);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -70,8 +73,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + 1)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + 1)..];
             return true;

--- a/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyStringSplitOptionsWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -33,6 +34,7 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -49,11 +51,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -62,7 +65,7 @@ namespace SpanExtensions.Enumerators
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -80,8 +83,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + 1)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + 1)..];
             return true;

--- a/src/Enumerators/SplitAny/SpanSplitAnyWithCountEnumerator.cs
+++ b/src/Enumerators/SplitAny/SpanSplitAnyWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly ReadOnlySpan<T> Delimiters;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -31,6 +32,7 @@ namespace SpanExtensions.Enumerators
             Count = count;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -47,11 +49,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -59,7 +62,7 @@ namespace SpanExtensions.Enumerators
             int index = span.IndexOfAny(Delimiters);
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceEnumerator.cs
@@ -10,6 +10,7 @@ namespace SpanExtensions.Enumerators
     {
         ReadOnlySpan<T> Span;
         readonly ReadOnlySpan<T> Delimiter;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -26,6 +27,7 @@ namespace SpanExtensions.Enumerators
             Span = source;
             Delimiter = delimiter;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -42,16 +44,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             int index = span.IndexOf(Delimiter);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsEnumerator.cs
@@ -10,6 +10,7 @@ namespace SpanExtensions.Enumerators
         ReadOnlySpan<char> Span;
         readonly ReadOnlySpan<char> Delimiter;
         readonly StringSplitOptions Options;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -28,6 +29,7 @@ namespace SpanExtensions.Enumerators
             Delimiter = delimiter;
             Options = options;
             Current = default;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -44,16 +46,17 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             int index = span.IndexOf(Delimiter);
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -70,8 +73,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + Delimiter.Length)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + Delimiter.Length)..];
             return true;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsWithCountEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceStringSplitOptionsWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly StringSplitOptions Options;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -33,6 +34,7 @@ namespace SpanExtensions.Enumerators
             Options = options;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -49,11 +51,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<char> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<char> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -62,7 +65,7 @@ namespace SpanExtensions.Enumerators
 
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<char>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }
@@ -80,8 +83,20 @@ namespace SpanExtensions.Enumerators
                 if(Current.IsEmpty)
                 {
                     Span = span[(index + Delimiter.Length)..];
+                    if(Span.IsEmpty)
+                    {
+                        enumerationDone = true;
+                        return false;
+                    }
                     return MoveNext();
                 }
+
+                Span = span[(index + 1)..];
+                if(Span.IsEmpty)
+                {
+                    enumerationDone = true;
+                }
+                return true;
             }
             Span = span[(index + Delimiter.Length)..];
             return true;

--- a/src/Enumerators/SplitSequence/SpanSplitSequenceWithCountEnumerator.cs
+++ b/src/Enumerators/SplitSequence/SpanSplitSequenceWithCountEnumerator.cs
@@ -12,6 +12,7 @@ namespace SpanExtensions.Enumerators
         readonly ReadOnlySpan<T> Delimiter;
         readonly int Count;
         int currentCount;
+        bool enumerationDone;
 
         /// <summary>
         /// Gets the element in the collection at the current position of the enumerator.
@@ -31,6 +32,7 @@ namespace SpanExtensions.Enumerators
             Count = count;
             Current = default;
             currentCount = 0;
+            enumerationDone = false;
         }
 
         /// <summary>
@@ -47,11 +49,12 @@ namespace SpanExtensions.Enumerators
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
         public bool MoveNext()
         {
-            ReadOnlySpan<T> span = Span;
-            if(span.IsEmpty)
+            if(enumerationDone)
             {
                 return false;
             }
+
+            ReadOnlySpan<T> span = Span;
             if(currentCount == Count)
             {
                 return false;
@@ -59,7 +62,7 @@ namespace SpanExtensions.Enumerators
             int index = span.IndexOf(Delimiter);
             if(index == -1 || index >= span.Length)
             {
-                Span = ReadOnlySpan<T>.Empty;
+                enumerationDone = true;
                 Current = span;
                 return true;
             }


### PR DESCRIPTION
If the last span in an enumeration was empty, it would be erroneously dropped.