### PR TITLE
Limit enumeration in tests

### DIFF
--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/Split.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/Split.cs
@@ -33,7 +33,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter),
-                            actual: array.AsReadOnlySpan().Split(delimiter).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().Split(delimiter).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: ("delimiter", delimiter)
@@ -68,7 +68,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter, count, countExceedingBehaviour),
-                            actual: array.AsReadOnlySpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitAny.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitAny.cs
@@ -49,7 +49,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: SplitAny(array, delimiters),
-                            actual: array.AsReadOnlySpan().SplitAny(delimiters).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().SplitAny(delimiters).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.SplitAny),
                             args: ("delimiters", delimiters)
@@ -87,7 +87,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: SplitAny(array, delimiters, count, countExceedingBehaviour),
-                            actual: array.AsReadOnlySpan().SplitAny(delimiters, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().SplitAny(delimiters, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitAnyString.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitAnyString.cs
@@ -46,7 +46,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiters, options),
-                            actual: @string.AsSpan().SplitAny(delimiters, options).ToSystemEnumerable(),
+                            actual: @string.AsSpan().SplitAny(delimiters, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("options", options)]
@@ -80,7 +80,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiters, count, options, countExceedingBehaviour),
-                            actual: @string.AsSpan().SplitAny(delimiters, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.AsSpan().SplitAny(delimiters, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitSequence.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitSequence.cs
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter),
-                            actual: array.AsReadOnlySpan().Split(delimiter).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().Split(delimiter).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: ("delimiter", delimiter)
@@ -74,7 +74,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter, count, countExceedingBehaviour),
-                            actual: array.AsReadOnlySpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsReadOnlySpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitString.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitString.cs
@@ -30,7 +30,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiter, options),
-                            actual: @string.AsSpan().Split(delimiter, options).ToSystemEnumerable(),
+                            actual: @string.AsSpan().Split(delimiter, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("options", options)]
@@ -63,7 +63,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiter, count, options, countExceedingBehaviour),
-                            actual: @string.AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitStringSequence.cs
+++ b/tests/fuzzing/Tests/ReadOnlySpan/Split/SplitStringSequence.cs
@@ -33,7 +33,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(new string(delimiter), options),
-                            actual: @string.AsSpan().Split(delimiter, options).ToSystemEnumerable(),
+                            actual: @string.AsSpan().Split(delimiter, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("options", options)]
@@ -67,7 +67,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(new string(delimiter), count, options, countExceedingBehaviour),
-                            actual: @string.AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(ReadOnlySpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/Split.cs
+++ b/tests/fuzzing/Tests/Span/Split/Split.cs
@@ -33,7 +33,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter),
-                            actual: array.AsSpan().Split(delimiter).ToSystemEnumerable(),
+                            actual: array.AsSpan().Split(delimiter).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.Split),
                             args: ("delimiter", delimiter)
@@ -68,7 +68,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter, count, countExceedingBehaviour),
-                            actual: array.AsSpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsSpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/SplitAny.cs
+++ b/tests/fuzzing/Tests/Span/Split/SplitAny.cs
@@ -49,7 +49,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: SplitAny(array, delimiters),
-                            actual: array.AsSpan().SplitAny(delimiters).ToSystemEnumerable(),
+                            actual: array.AsSpan().SplitAny(delimiters).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.SplitAny),
                             args: ("delimiters", delimiters)
@@ -87,7 +87,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: SplitAny(array, delimiters, count, countExceedingBehaviour),
-                            actual: array.AsSpan().SplitAny(delimiters, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsSpan().SplitAny(delimiters, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/SplitAnyString.cs
+++ b/tests/fuzzing/Tests/Span/Split/SplitAnyString.cs
@@ -46,7 +46,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiters, options),
-                            actual: @string.ToCharArray().AsSpan().SplitAny(delimiters, options).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().SplitAny(delimiters, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("options", options)]
@@ -80,7 +80,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiters, count, options, countExceedingBehaviour),
-                            actual: @string.ToCharArray().AsSpan().SplitAny(delimiters, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().SplitAny(delimiters, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.SplitAny),
                             args: [("delimiters", delimiters), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/SplitSequence.cs
+++ b/tests/fuzzing/Tests/Span/Split/SplitSequence.cs
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter),
-                            actual: array.AsSpan().Split(delimiter).ToSystemEnumerable(),
+                            actual: array.AsSpan().Split(delimiter).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.Split),
                             args: ("delimiter", delimiter)
@@ -74,7 +74,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: Split(array, delimiter, count, countExceedingBehaviour),
-                            actual: array.AsSpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: array.AsSpan().Split(delimiter, count, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * array.Length),
                             source: array,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/SplitString.cs
+++ b/tests/fuzzing/Tests/Span/Split/SplitString.cs
@@ -30,7 +30,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiter, options),
-                            actual: @string.ToCharArray().AsSpan().Split(delimiter, options).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().Split(delimiter, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("options", options)]
@@ -63,7 +63,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(delimiter, count, options, countExceedingBehaviour),
-                            actual: @string.ToCharArray().AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/Tests/Span/Split/SplitStringSequence.cs
+++ b/tests/fuzzing/Tests/Span/Split/SplitStringSequence.cs
@@ -33,7 +33,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(new string(delimiter), options),
-                            actual: @string.ToCharArray().AsSpan().Split(delimiter, options).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().Split(delimiter, options).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("options", options)]
@@ -67,7 +67,7 @@ namespace SpanExtensions.Tests.Fuzzing
                     {
                         AssertMethodResults(
                             expected: @string.Split(new string(delimiter), count, options, countExceedingBehaviour),
-                            actual: @string.ToCharArray().AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(),
+                            actual: @string.ToCharArray().AsSpan().Split(delimiter, count, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 2 * @string.Length),
                             source: @string,
                             method: nameof(SpanExtensions.Split),
                             args: [("delimiter", delimiter), ("count", count), ("options", options), ("countExceedingBehaviour", countExceedingBehaviour)]

--- a/tests/fuzzing/ToSystemEnumerableExtensions.cs
+++ b/tests/fuzzing/ToSystemEnumerableExtensions.cs
@@ -8,145 +8,205 @@ namespace SpanExtensions.Tests.Fuzzing
     /// </summary>
     public static class ToSystemEnumerableExtensions
     {
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/Split.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/Split.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".AsSpan().Split('a').ToSystemEnumerable()
+                    "".AsSpan().Split('a').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split('c').ToSystemEnumerable()
+                    "abba".AsSpan().Split('c').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -47,11 +47,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".AsSpan().Split('a', 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().Split('a', 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".AsSpan().Split('c', 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().Split('c', 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -61,11 +61,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split('a', 1).ToSystemEnumerable()
+                    "abba".AsSpan().Split('a', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split('c', 1).ToSystemEnumerable()
+                    "abba".AsSpan().Split('c', 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -74,7 +74,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".AsSpan().Split('b').ToSystemEnumerable()
+                    "abba".AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,7 +83,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".AsSpan().Split('b').ToSystemEnumerable()
+                    "baa".AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -92,7 +92,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".AsSpan().Split('b').ToSystemEnumerable()
+                    "aab".AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -101,11 +101,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aabaabaa".AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -114,11 +114,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aab".AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aabab".AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabab".AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -126,20 +126,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aab".AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aab".AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabab".AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaa".AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -148,11 +148,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".AsSpan().Split('b', 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaabaa".AsSpan().Split('b', 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitAny.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitAny.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".AsSpan().SplitAny(['a', 'b']).ToSystemEnumerable()
+                    "".AsSpan().SplitAny(['a', 'b']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny(['c', 'd']).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['c', 'd']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -45,7 +45,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny([]).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny([]).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -56,11 +56,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".AsSpan().SplitAny(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().SplitAny(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".AsSpan().SplitAny(['c', 'd'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().SplitAny(['c', 'd'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny(['a', 'b'], 1).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['a', 'b'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny(['c', 'd'], 1).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['c', 'd'], 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,11 +83,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abca".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "abca".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -96,11 +96,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "baa".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "caa".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "caa".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -109,11 +109,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aac".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "aac".AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -122,19 +122,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c', 'a', 'a']],
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'c', 'a', 'a']],
-                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -143,19 +143,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c']],
-                    "aac".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aac".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'c']],
-                    "aabac".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabac".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aacab".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacab".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -163,20 +163,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabac".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabac".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabac".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabac".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -185,19 +185,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitAnyString.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitAnyString.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".AsSpan().SplitAny(['a', 'b'], options).ToSystemEnumerable()
+                            "".AsSpan().SplitAny(['a', 'b'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".AsSpan().SplitAny(['c', 'd'], options).ToSystemEnumerable()
+                        "abba".AsSpan().SplitAny(['c', 'd'], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -56,7 +56,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [['a'], ['b'], ['c'], ['d']],
-                        "a b c d".AsSpan().SplitAny([], StringSplitOptions.None).ToSystemEnumerable()
+                        "a b c d".AsSpan().SplitAny([], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".AsSpan().SplitAny(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().SplitAny(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".AsSpan().SplitAny(['c', 'd'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().SplitAny(['c', 'd'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -85,11 +85,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().SplitAny(['c', 'd'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['c', 'd'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -98,11 +98,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abca".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abca".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -115,11 +115,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abba".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "abba".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a'], ['a']],
-                            "abca".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "abca".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -130,11 +130,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "baa".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "caa".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "caa".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -147,11 +147,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "baa".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "baa".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "caa".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "caa".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -162,11 +162,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aac".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aac".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -179,11 +179,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aab".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "aab".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "aac".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "aac".AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -194,19 +194,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c', 'a', 'a']],
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'c', 'a', 'a']],
-                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -215,19 +215,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c']],
-                    "aac".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aac".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'c']],
-                    "aabac".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabac".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aacab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -235,20 +235,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -257,19 +257,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaacaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaabaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -282,11 +282,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabb".AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabb".AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "aabc".AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabc".AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -297,11 +297,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    " a b b a ".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a b b a ".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    " a b c a ".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a b c a ".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -310,7 +310,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().SplitAny(['_', '!'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".AsSpan().SplitAny(['_', '!'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -319,11 +319,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabb".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabb".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aabc".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabc".AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -332,7 +332,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -341,11 +341,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'a', 'a']],
-                    "baa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', 'a', 'a']],
-                    "bcaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -354,11 +354,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "baa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bcaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -367,7 +367,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -376,11 +376,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', '\t', 'a', 'a']],
-                    " b\taa\n".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', '\t', 'c', '\n', 'a', 'a']],
-                    " b\tc\naa\r".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tc\naa\r".AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -389,11 +389,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " b\taa\n".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " b\tc\naa\r".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tc\naa\r".AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -403,16 +403,16 @@ namespace SpanExtensions.Tests.UnitTests
                 foreach(StringSplitOptions options in stringSplitOptions)
                 {
                     AssertEqual(
-                        "".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        "".AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        "".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        "".AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
-                        " ".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        " ".AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        " ".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        " ".AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
-                        " aabb ".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        " aabb ".AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        " aabb ".AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        " aabb ".AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitSequence.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitSequence.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".AsSpan().Split(['a', 'b']).ToSystemEnumerable()
+                    "".AsSpan().Split(['a', 'b']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "abba".AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -45,7 +45,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split([]).ToSystemEnumerable()
+                    "abba".AsSpan().Split([]).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -56,11 +56,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".AsSpan().Split(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().Split(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".AsSpan().Split(['b', 'c'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".AsSpan().Split(['b', 'c'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split(['a', 'b'], 1).ToSystemEnumerable()
+                    "abba".AsSpan().Split(['a', 'b'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "abba".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,7 +83,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abcbca".AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "abcbca".AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -92,7 +92,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "bcaa".AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "bcaa".AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -101,7 +101,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aabc".AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -110,11 +110,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -123,11 +123,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c']],
-                    "aabc".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b', 'c']],
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -135,20 +135,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabc".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabc".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabc".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -157,11 +157,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitString.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitString.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".AsSpan().Split('a', options).ToSystemEnumerable()
+                            "".AsSpan().Split('a', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".AsSpan().Split('c', options).ToSystemEnumerable()
+                        "abba".AsSpan().Split('c', options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -58,11 +58,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".AsSpan().Split('a', 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().Split('a', 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".AsSpan().Split('c', 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().Split('c', 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -73,11 +73,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split('a', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split('a', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split('c', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split('c', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -86,7 +86,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -99,7 +99,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abba".AsSpan().Split('b', options).ToSystemEnumerable()
+                            "abba".AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -110,7 +110,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "baa".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -123,7 +123,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "baa".AsSpan().Split('b', options).ToSystemEnumerable()
+                            "baa".AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -134,7 +134,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -147,7 +147,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aab".AsSpan().Split('b', options).ToSystemEnumerable()
+                            "aab".AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -158,11 +158,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -171,11 +171,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -183,20 +183,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -205,11 +205,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaabaa".AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -222,7 +222,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabb".AsSpan().Split('b', 2, options).ToSystemEnumerable()
+                            "aabb".AsSpan().Split('b', 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -233,7 +233,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], ['a']],
-                    " a\tb\na\r".AsSpan().Split('b', StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a\tb\na\r".AsSpan().Split('b', StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -242,7 +242,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().Split('_', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".AsSpan().Split('_', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -251,7 +251,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabb".AsSpan().Split('b', StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabb".AsSpan().Split('b', StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -260,7 +260,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -269,11 +269,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'a', 'a']],
-                    "baa".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'b', 'a', 'a']],
-                    "bbaa".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bbaa".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -282,11 +282,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "baa".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bbaa".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bbaa".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -295,7 +295,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -304,11 +304,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', '\t', 'a', 'a']],
-                    " b\taa\n".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', '\t', 'b', '\n', 'a', 'a']],
-                    " b\tb\naa\r".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tb\naa\r".AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -317,11 +317,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " b\taa\n".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " b\tb\naa\r".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tb\naa\r".AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitStringSequence.cs
+++ b/tests/unit-tests/Tests/ReadOnlySpan/Split/SplitStringSequence.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                        "abba".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -54,7 +54,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split([], StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split([], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -67,11 +67,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".AsSpan().Split(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().Split(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".AsSpan().Split(['b', 'c'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".AsSpan().Split(['b', 'c'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -82,11 +82,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -95,7 +95,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abcbca".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abcbca".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -108,7 +108,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abcbca".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "abcbca".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -119,7 +119,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "bcaa".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "bcaa".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -132,7 +132,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "bcaa".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "bcaa".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -143,7 +143,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aabc".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -156,7 +156,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabc".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "aabc".AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -167,11 +167,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -180,11 +180,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c']],
-                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b', 'c']],
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -192,20 +192,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabc".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcabc".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -214,11 +214,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaabcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -231,7 +231,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabcbc".AsSpan().Split(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabcbc".AsSpan().Split(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -242,7 +242,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], ['a']],
-                    " a\tbc\na\r".AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a\tbc\na\r".AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -251,7 +251,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -260,7 +260,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcbc".AsSpan().Split(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabcbc".AsSpan().Split(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -269,7 +269,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -278,11 +278,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'c', 'a', 'a']],
-                    "bcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', 'b', 'c', 'a', 'a']],
-                    "bcbcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcbcaa".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -291,11 +291,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "bcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bcbcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcbcaa".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -304,7 +304,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -313,11 +313,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'c', '\t', 'a', 'a']],
-                    " bc\taa\n".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\taa\n".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', '\t', 'b', 'c', '\n', 'a', 'a']],
-                    " bc\tbc\naa\r".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\tbc\naa\r".AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -326,11 +326,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " bc\taa\n".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\taa\n".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " bc\tbc\naa\r".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\tbc\naa\r".AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/Span/Split/Split.cs
+++ b/tests/unit-tests/Tests/Span/Split/Split.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".ToCharArray().AsSpan().Split('a').ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().Split('a').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split('c').ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('c').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -47,11 +47,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().Split('a', 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split('a', 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().Split('c', 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split('c', 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -61,11 +61,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split('a', 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('a', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split('c', 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('c', 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -74,7 +74,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".ToCharArray().AsSpan().Split('b').ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,7 +83,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".ToCharArray().AsSpan().Split('b').ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -92,7 +92,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".ToCharArray().AsSpan().Split('b').ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b').ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -101,11 +101,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -114,11 +114,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aabab".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabab".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -126,20 +126,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aab".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabab".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -148,11 +148,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/Span/Split/SplitAny.cs
+++ b/tests/unit-tests/Tests/Span/Split/SplitAny.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".ToCharArray().AsSpan().SplitAny(['a', 'b']).ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().SplitAny(['a', 'b']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd']).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -45,7 +45,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny([]).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny([]).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -56,11 +56,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,11 +83,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abca".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "abca".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -96,11 +96,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "caa".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "caa".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -109,11 +109,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable()
+                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -122,19 +122,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c', 'a', 'a']],
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'c', 'a', 'a']],
-                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -143,19 +143,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c']],
-                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'c']],
-                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aacab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -163,20 +163,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable()
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable()
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -185,19 +185,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/Span/Split/SplitAnyString.cs
+++ b/tests/unit-tests/Tests/Span/Split/SplitAnyString.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".ToCharArray().AsSpan().SplitAny(['a', 'b'], options).ToSystemEnumerable()
+                            "".ToCharArray().AsSpan().SplitAny(['a', 'b'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], options).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -56,7 +56,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [['a'], ['b'], ['c'], ['d']],
-                        "a b c d".ToCharArray().AsSpan().SplitAny([], StringSplitOptions.None).ToSystemEnumerable()
+                        "a b c d".ToCharArray().AsSpan().SplitAny([], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -85,11 +85,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['c', 'd'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -98,11 +98,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abca".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abca".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -115,11 +115,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abba".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a'], ['a']],
-                            "abca".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "abca".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -130,11 +130,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "caa".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "caa".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -147,11 +147,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "caa".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "caa".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -162,11 +162,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -179,11 +179,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable()
+                            "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -194,19 +194,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c', 'a', 'a']],
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'c', 'a', 'a']],
-                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -215,19 +215,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a', 'c']],
-                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'c']],
-                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabac".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aacab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aacab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -235,20 +235,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -257,19 +257,19 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaacaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aacaabaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -282,11 +282,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabb".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabb".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [['a', 'a']],
-                            "aabc".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabc".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -297,11 +297,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    " a b b a ".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a b b a ".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a'], [], ['a']],
-                    " a b c a ".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a b c a ".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -310,7 +310,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().SplitAny(['_', '!'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().SplitAny(['_', '!'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -319,11 +319,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabb".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabb".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "aabc".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().SplitAny(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -332,7 +332,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -341,11 +341,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'a', 'a']],
-                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', 'a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -354,11 +354,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -367,7 +367,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -376,11 +376,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', '\t', 'a', 'a']],
-                    " b\taa\n".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', '\t', 'c', '\n', 'a', 'a']],
-                    " b\tc\naa\r".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tc\naa\r".ToCharArray().AsSpan().SplitAny(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -389,11 +389,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " b\taa\n".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " b\tc\naa\r".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tc\naa\r".ToCharArray().AsSpan().SplitAny(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -403,16 +403,16 @@ namespace SpanExtensions.Tests.UnitTests
                 foreach(StringSplitOptions options in stringSplitOptions)
                 {
                     AssertEqual(
-                        "".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        "".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        "".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        "".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
-                        " ".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        " ".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        " ".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        " ".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
-                        " aabb ".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(),
-                        " aabb ".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable()
+                        " aabb ".ToCharArray().AsSpan().SplitAny([], 1, options).ToSystemEnumerable(maxCount: 100),
+                        " aabb ".ToCharArray().AsSpan().SplitAny([], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }

--- a/tests/unit-tests/Tests/Span/Split/SplitSequence.cs
+++ b/tests/unit-tests/Tests/Span/Split/SplitSequence.cs
@@ -27,7 +27,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[]],
-                    "".ToCharArray().AsSpan().Split(['a', 'b']).ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().Split(['a', 'b']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -36,7 +36,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -45,7 +45,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split([]).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split([]).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -56,11 +56,11 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().Split(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split(['a', 'b'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                     AssertEqual(
                         [],
-                        "abba".ToCharArray().AsSpan().Split(['b', 'c'], 0, countExceedingBehaviour).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split(['b', 'c'], 0, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -70,11 +70,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split(['a', 'b'], 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split(['a', 'b'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -83,7 +83,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abcbca".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "abcbca".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -92,7 +92,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -101,7 +101,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c']).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -110,11 +110,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -123,11 +123,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c']],
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b', 'c']],
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -135,20 +135,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -157,11 +157,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/Span/Split/SplitString.cs
+++ b/tests/unit-tests/Tests/Span/Split/SplitString.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".ToCharArray().AsSpan().Split('a', options).ToSystemEnumerable()
+                            "".ToCharArray().AsSpan().Split('a', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".ToCharArray().AsSpan().Split('c', options).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split('c', options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -58,11 +58,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().Split('a', 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().Split('a', 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().Split('c', 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().Split('c', 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -73,11 +73,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split('a', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('a', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split('c', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('c', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -86,7 +86,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abba".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -99,7 +99,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abba".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -110,7 +110,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "baa".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -123,7 +123,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "baa".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable()
+                            "baa".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -134,7 +134,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aab".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b', StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -147,7 +147,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aab".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable()
+                            "aab".ToCharArray().AsSpan().Split('b', options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -158,11 +158,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'a', 'a']],
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -171,11 +171,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b']],
-                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b']],
-                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -183,20 +183,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aab".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabab".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -205,11 +205,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabaabaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -222,7 +222,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabb".ToCharArray().AsSpan().Split('b', 2, options).ToSystemEnumerable()
+                            "aabb".ToCharArray().AsSpan().Split('b', 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -233,7 +233,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], ['a']],
-                    " a\tb\na\r".ToCharArray().AsSpan().Split('b', StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a\tb\na\r".ToCharArray().AsSpan().Split('b', StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -242,7 +242,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().Split('_', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().Split('_', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -251,7 +251,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabb".ToCharArray().AsSpan().Split('b', StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabb".ToCharArray().AsSpan().Split('b', StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -260,7 +260,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -269,11 +269,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'a', 'a']],
-                    "baa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'b', 'a', 'a']],
-                    "bbaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bbaa".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -282,11 +282,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "baa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "baa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bbaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bbaa".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -295,7 +295,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -304,11 +304,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', '\t', 'a', 'a']],
-                    " b\taa\n".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', '\t', 'b', '\n', 'a', 'a']],
-                    " b\tb\naa\r".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tb\naa\r".ToCharArray().AsSpan().Split('b', 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -317,11 +317,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " b\taa\n".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\taa\n".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " b\tb\naa\r".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " b\tb\naa\r".ToCharArray().AsSpan().Split('b', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/Tests/Span/Split/SplitStringSequence.cs
+++ b/tests/unit-tests/Tests/Span/Split/SplitStringSequence.cs
@@ -31,7 +31,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [[]],
-                            "".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -44,7 +44,7 @@ namespace SpanExtensions.Tests.UnitTests
                 {
                     AssertEqual(
                         ["abba".ToCharArray()],
-                        "abba".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                        "abba".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                     );
                 }
             }
@@ -54,7 +54,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split([], StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split([], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -67,11 +67,11 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().Split(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().Split(['a', 'b'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                         AssertEqual(
                             [],
-                            "abba".ToCharArray().AsSpan().Split(['b', 'c'], 0, options, countExceedingBehaviour).ToSystemEnumerable()
+                            "abba".ToCharArray().AsSpan().Split(['b', 'c'], 0, options, countExceedingBehaviour).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -82,11 +82,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split(['a', 'b'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     ["abba".ToCharArray()],
-                    "abba".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "abba".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -95,7 +95,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], [], ['a']],
-                    "abcbca".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "abcbca".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -108,7 +108,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a'], ['a']],
-                            "abcbca".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "abcbca".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -119,7 +119,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [[], ['a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -132,7 +132,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -143,7 +143,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a'], []],
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -156,7 +156,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabc".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable()
+                            "aabc".ToCharArray().AsSpan().Split(['b', 'c'], options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -167,11 +167,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a', 'b', 'c', 'a', 'a']],
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -180,11 +180,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a', 'b', 'c']],
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'b', 'c']],
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -192,20 +192,20 @@ namespace SpanExtensions.Tests.UnitTests
             public void DefaultCountExceedingBehaviourOptionIsAppendRemainingElements()
             {
                 AssertEqual(
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabc".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(),
-                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable()
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.AppendRemainingElements).ToSystemEnumerable(maxCount: 100),
+                    "aabcabc".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -214,11 +214,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a'], ['a', 'a']],
-                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable()
+                    "aabcaabcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.None, CountExceedingBehaviour.CutRemainingElements).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -231,7 +231,7 @@ namespace SpanExtensions.Tests.UnitTests
                     {
                         AssertEqual(
                             [['a', 'a']],
-                            "aabcbc".ToCharArray().AsSpan().Split(['b', 'c'], 2, options).ToSystemEnumerable()
+                            "aabcbc".ToCharArray().AsSpan().Split(['b', 'c'], 2, options).ToSystemEnumerable(maxCount: 100)
                         );
                     }
                 }
@@ -242,7 +242,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a'], ['a']],
-                    " a\tbc\na\r".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " a\tbc\na\r".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -251,7 +251,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -260,7 +260,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "aabcbc".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "aabcbc".ToCharArray().AsSpan().Split(['b', 'c'], StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -269,7 +269,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    "".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -278,11 +278,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'c', 'a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', 'b', 'c', 'a', 'a']],
-                    "bcbcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcbcaa".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -291,11 +291,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    "bcbcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable()
+                    "bcbcaa".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -304,7 +304,7 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [],
-                    " \t".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " \t".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -313,11 +313,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['b', 'c', '\t', 'a', 'a']],
-                    " bc\taa\n".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\taa\n".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['b', 'c', '\t', 'b', 'c', '\n', 'a', 'a']],
-                    " bc\tbc\naa\r".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\tbc\naa\r".ToCharArray().AsSpan().Split(['b', 'c'], 1, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 
@@ -326,11 +326,11 @@ namespace SpanExtensions.Tests.UnitTests
             {
                 AssertEqual(
                     [['a', 'a']],
-                    " bc\taa\n".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\taa\n".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
                 AssertEqual(
                     [['a', 'a']],
-                    " bc\tbc\naa\r".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable()
+                    " bc\tbc\naa\r".ToCharArray().AsSpan().Split(['b', 'c'], 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToSystemEnumerable(maxCount: 100)
                 );
             }
 

--- a/tests/unit-tests/ToSystemEnumerableExtensions.cs
+++ b/tests/unit-tests/ToSystemEnumerableExtensions.cs
@@ -8,145 +8,205 @@ namespace SpanExtensions.Tests.UnitTests
     /// </summary>
     public static class ToSystemEnumerableExtensions
     {
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if (list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitAnyWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitAnyStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceWithCountEnumerator<T> spanEnumerator) where T : IEquatable<T>
+        public static IEnumerable<IEnumerable<T>> ToSystemEnumerable<T>(this SpanSplitSequenceWithCountEnumerator<T> spanEnumerator, int maxCount = int.MaxValue) where T : IEquatable<T>
         {
             List<T[]> list = [];
 
             foreach(ReadOnlySpan<T> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;
         }
 
-        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsWithCountEnumerator spanEnumerator)
+        public static IEnumerable<IEnumerable<char>> ToSystemEnumerable(this SpanSplitSequenceStringSplitOptionsWithCountEnumerator spanEnumerator, int maxCount = int.MaxValue)
         {
             List<char[]> list = [];
 
             foreach(ReadOnlySpan<char> element in spanEnumerator)
             {
                 list.Add(element.ToArray());
+
+                if(list.Count >= maxCount)
+                {
+                    throw new IndexOutOfRangeException($"Enumeration exceeded {maxCount}.");
+                }
             }
 
             return list;


### PR DESCRIPTION
This fixes an oversight in #9 that didn't account for the possibility that the implementation being tested could return infinite enumeration. This adds a `maxCount` parameter to the `ToSystemEnumerable` extension methods that throws an exception (stopping the test) if the SpanEnumerable returns more the specified number of spans.

Note: This assumes that the underlying SpanEnumerable implementation returns spans. This will not detect if the implementation gets stuck in an infinite loop that never returns! Infinite recursions should be caught by the tests once they run out of stack memory.