### PR TITLE
Version 1.4.2

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,8 +1,8 @@
 # SpanExtensions
 
-![NuGet Version](https://img.shields.io/nuget/v/SpanExtensions.Net)
-![NuGet Downloads](https://img.shields.io/nuget/dt/SpanExtensions.Net)
-![GitHub License](https://img.shields.io/github/license/draconware-dev/SpanExtensions.Net)
+[![NuGet Version](https://img.shields.io/nuget/v/SpanExtensions.Net)](https://www.nuget.org/packages/SpanExtensions.Net)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/SpanExtensions.Net)](https://www.nuget.org/packages/SpanExtensions.Net)
+[![GitHub License](https://img.shields.io/github/license/draconware-dev/SpanExtensions.Net)](https://github.com/draconware-dev/SpanExtensions.Net/blob/main/LICENSE)
 
 ## About
 **`ReadonlySpan<T>`** and **`Span<T>`** are great Types in _C#_, but unfortunately working with them can sometimes be sort of a hassle and some use cases seem straight up impossible, even though they are not.  

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,8 @@
 # SpanExtensions
 
-[![NuGet Badge](https://buildstats.info/nuget/SpanExtensions.Net)](https://www.nuget.org/packages/SpanExtensions.Net)
+![NuGet Version](https://img.shields.io/nuget/v/SpanExtensions.Net)
+![NuGet Downloads](https://img.shields.io/nuget/dt/SpanExtensions.Net)
+![GitHub License](https://img.shields.io/github/license/draconware-dev/SpanExtensions.Net)
 
 ## About
 **`ReadonlySpan<T>`** and **`Span<T>`** are great Types in _C#_, but unfortunately working with them can sometimes be sort of a hassle and some use cases seem straight up impossible, even though they are not.  

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,8 @@ name: Format
 on:
   push:
     branches: [ "dev" ]
+    paths:
+    - '**.cs'
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ name: .NET
 on:
   push:
     branches: [ "main" ]
+    paths:
+    - '**.cs'
+    - '**.csproj'
+    - '**.sln'
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     paths:
     - '**.cs'
     - '**.csproj'
+    - '**.sln'
 
 jobs:
   test:

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres not (yet) to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.2] - 2024-10-29
+
+### Added 
+
+- `(Readonly-)Span<T>.Count(...)` overloads to all versions before .Net 8 matching these introduced in .Net 8.
+
+### Changed 
+
+- blocked compilation on .Net 9 due to known incompatibilities, which are to be resolved in version 1.5. 
+
 ## [1.4.1] - 2024-9-9
 
 ### Fixed 

--- a/src/Extensions/ReadOnlySpan/Linq/Count.cs
+++ b/src/Extensions/ReadOnlySpan/Linq/Count.cs
@@ -47,5 +47,48 @@ namespace SpanExtensions
 
             return count;
         }
+
+#if !NET8_0_OR_GREATER
+        /// <summary>Counts the number of times the specified <paramref name="value"/> occurs in the <paramref name="source"/>.</summary>
+        /// <typeparam name="T">The element type of the span.</typeparam>
+        /// <param name="source">A <see cref="ReadOnlySpan{T}"/> whose elements are to be counted.</param>
+        /// <param name="value">The value for which to search.</param>
+        /// <returns>The number of elements eqaul to <paramref name="value"/> in <paramref name="source"/>.</returns>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="int.MaxValue"/>.</exception>
+        public static int Count<T>(this ReadOnlySpan<T> source, T value) where T : IEquatable<T>
+        {
+            int count = 0;
+
+            foreach(var item in source)
+            {
+                if(item.Equals(value))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>Counts the number of times the specified <paramref name="value"/> occurs in the <paramref name="source"/>.</summary>
+        /// <typeparam name="T">The element type of the span.</typeparam>
+        /// <param name="source">A <see cref="ReadOnlySpan{T}"/> whose elements are to be counted.</param>
+        /// <param name="value">The value for which to search.</param>
+        /// <returns>The number of elements eqaul to <paramref name="value"/> in <paramref name="source"/>.</returns>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="int.MaxValue"/>.</exception>
+        public static int Count<T>(this ReadOnlySpan<T> source, ReadOnlySpan<T> value) where T : IEquatable<T>
+        {
+            int count = 0;
+            int current = 0;
+
+            while((current = source.IndexOf(value)) != -1)
+            {
+                source = source.Slice(current + value.Length);
+                count++;
+            }
+
+            return count;
+        }
+#endif
     }
 }

--- a/src/Extensions/Span/Linq/Count.cs
+++ b/src/Extensions/Span/Linq/Count.cs
@@ -29,5 +29,29 @@ namespace SpanExtensions
         {
             return ReadOnlySpanExtensions.Count(source, predicate);
         }
+
+#if !NET8_0_OR_GREATER
+        /// <summary>Counts the number of times the specified <paramref name="value"/> occurs in the <paramref name="source"/>.</summary>
+        /// <typeparam name="T">The element type of the span.</typeparam>
+        /// <param name="source">A <see cref="Span{T}"/> whose elements are to be counted.</param>
+        /// <param name="value">The value for which to search.</param>
+        /// <returns>The number of elements eqaul to <paramref name="value"/> in <paramref name="source"/>.</returns>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="int.MaxValue"/>.</exception>
+        public static int Count<T>(this Span<T> source, T value) where T : IEquatable<T>
+        {
+            return ReadOnlySpanExtensions.Count(source, value);
+        }
+
+        /// <summary>Counts the number of times the specified <paramref name="value"/> occurs in the <paramref name="source"/>.</summary>
+        /// <typeparam name="T">The element type of the span.</typeparam>
+        /// <param name="source">A <see cref="Span{T}"/> whose elements are to be counted.</param>
+        /// <param name="value">The value for which to search.</param>
+        /// <returns>The number of elements eqaul to <paramref name="value"/> in <paramref name="source"/>.</returns>
+        /// <exception cref="OverflowException">The number of elements in <paramref name="source"/> is larger than <see cref="int.MaxValue"/>.</exception>
+        public static int Count<T>(this Span<T> source, ReadOnlySpan<T> value) where T : IEquatable<T>
+        {
+            return ReadOnlySpanExtensions.Count(source, value);
+        }
+#endif
     }
 }

--- a/src/SpanExtensions.csproj
+++ b/src/SpanExtensions.csproj
@@ -27,6 +27,10 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
+	
+	<Target Name="BlokcCompilationDotNet9Onwards" BeforeTargets="Compile">
+		<Error Condition="'$(TargetFramework)' == 'net9.0'" Text="Error: This project does not support versions past .NET 8. Please upgrade to the latest version of SpanExtensions.Net. Due to the introduction of the new variable-length Split methods in .Net 9, the rich set of Split extension methods provided by this package has been removed in favour of the new built-in versions. If you wish to continue using our rich set of methds over the new Split versions, they are still available under 'ReadOnlySpanExtensions.Split(...)' and 'SpanExtensions.Split(...)' respectively." />
+	</Target>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DebugType>portable</DebugType>

--- a/src/SpanExtensions.csproj
+++ b/src/SpanExtensions.csproj
@@ -22,7 +22,7 @@
 		<PackageTags>Span;Performance;Extension;String</PackageTags>
 		<PackageReleaseNotes>https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md</PackageReleaseNotes> 
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.4.1</Version>
+		<Version>1.4.2</Version>
 		<PackageId>SpanExtensions.Net</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Many (Readonly-)Span<T>.Count(...) overloads matching these introduced in .Net 8 have been added to all versions before .Net 8.
Additionally, compilation on .Net 9 has been blocked temporarily due to known incompatibilities.  
  
**Full Changelog**: https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md