### PR TITLE
Version 1.5.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres not (yet) to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2024-12-14
+
+### Fixed
+
+- incorrect ranges returned by the range-based Split method for versions prior to .Net 9.
+
+### Changed 
+
+- moved MemoryExtensions containing range-based Split method for versions prior to .Net 9 from `System` to `SpanExtensions`.
+- grammatical issues in some documentation comments.
+
 ## [1.5] - 2024-11-12
 
 ### Added

--- a/src/Enumerators/System/SpanSplitEnumerator.cs
+++ b/src/Enumerators/System/SpanSplitEnumerator.cs
@@ -1,10 +1,11 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 #if !NET9_0_OR_GREATER
 
-namespace System
+namespace SpanExtensions
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public static partial class MemoryExtensions
@@ -144,5 +145,4 @@ namespace System
         }
     }
 }
-
 #endif

--- a/src/Enumerators/System/SpanSplitEnumerator.cs
+++ b/src/Enumerators/System/SpanSplitEnumerator.cs
@@ -30,7 +30,7 @@ namespace SpanExtensions
             /// <summary>
             /// Gets the current element of the enumeration.
             /// </summary>
-            /// <returns>Returns a <see cref="Range"/> instance that indicates the bounds of the current element withing the source span.</returns>
+            /// <returns>Returns a <see cref="Range"/> instance that indicates the bounds of the current element within the source span.</returns>
             public readonly Range Current => new Range(currentStartIndex, currentEndIndex);
 
             internal SpanSplitEnumerator(ReadOnlySpan<T> source, T delimiter)

--- a/src/Enumerators/System/SpanSplitEnumerator.cs
+++ b/src/Enumerators/System/SpanSplitEnumerator.cs
@@ -23,27 +23,35 @@ namespace System
             readonly SearchValues<T> SearchValues = null!;
 #endif
 
+            int currentStartIndex;
+            int currentEndIndex;
+            int nextStartIndex;
             /// <summary>
             /// Gets the current element of the enumeration.
             /// </summary>
             /// <returns>Returns a <see cref="Range"/> instance that indicates the bounds of the current element withing the source span.</returns>
-            public Range Current { get; internal set; }
+            public readonly Range Current => new Range(currentStartIndex, currentEndIndex);
 
             internal SpanSplitEnumerator(ReadOnlySpan<T> source, T delimiter)
             {
                 Span = source;
                 Delimiter = delimiter;
-                Current = new Range(0, 0);
                 DelimiterSpan = default;
                 mode = SpanSplitEnumeratorMode.Delimiter;
+                currentStartIndex = 0;
+                currentEndIndex = 0;
+                nextStartIndex = 0;
             }
+
             internal SpanSplitEnumerator(ReadOnlySpan<T> source, ReadOnlySpan<T> delimiter, SpanSplitEnumeratorMode mode)
             {
                 Span = source;
                 DelimiterSpan = delimiter;
-                Current = new Range(0, 0);
                 Delimiter = default!;
                 this.mode = mode;
+                currentStartIndex = 0;
+                currentEndIndex = 0;
+                nextStartIndex = 0;
             }
 
 #if NET8_0
@@ -52,9 +60,11 @@ namespace System
                 Span = source;
                 Delimiter = default!;
                 SearchValues = searchValues;
-                Current = new Range(0, 0);
                 DelimiterSpan = default;
                 mode = SpanSplitEnumeratorMode.Delimiter;
+                currentStartIndex = 0;
+                currentEndIndex = 0;
+                nextStartIndex = 0;
             }
 #endif
             /// <summary>
@@ -106,15 +116,20 @@ namespace System
                         return false;
                 }
 
+                currentStartIndex = nextStartIndex;
+                
                 if(index < 0)
                 {
-                    Current = new Range(Span.Length, Span.Length);
+                    currentEndIndex = Span.Length;
+                    nextStartIndex = Span.Length;
+                    
                     mode = (SpanSplitEnumeratorMode)(-1);
                     return true;
                 }
 
-                Current = new Range(Current.End.Value + length, Current.Start.Value + index);
-
+                currentEndIndex = currentStartIndex + index;
+                nextStartIndex = currentEndIndex + length;
+                
                 return true;
             }
         }

--- a/src/Enumerators/System/SpanSplitEnumerator.cs
+++ b/src/Enumerators/System/SpanSplitEnumerator.cs
@@ -88,17 +88,17 @@ namespace SpanExtensions
                 switch(mode)
                 {
                     case SpanSplitEnumeratorMode.Delimiter:
-                        index = Span[Current.Start..].IndexOf(Delimiter);
+                        index = Span[nextStartIndex..].IndexOf(Delimiter);
                         length = 1;
                         break;
 
                     case SpanSplitEnumeratorMode.Any:
-                        index = Span[Current.Start..].IndexOfAny(DelimiterSpan);
+                        index = Span[nextStartIndex..].IndexOfAny(DelimiterSpan);
                         length = 1;
                         break;
 
                     case SpanSplitEnumeratorMode.Sequence:
-                        index = Span[Current.Start..].IndexOf(DelimiterSpan);
+                        index = Span[nextStartIndex..].IndexOf(DelimiterSpan);
                         length = DelimiterSpan.Length;
                         break;
 
@@ -109,7 +109,7 @@ namespace SpanExtensions
 
 #if NET8_0
                     case SpanSplitEnumeratorMode.SearchValues:
-                        index = Span[Current.Start..].IndexOfAny(SearchValues);
+                        index = Span[nextStartIndex..].IndexOfAny(SearchValues);
                         length = 1;
                         break;
 #endif

--- a/src/Extensions/ReadOnlySpan/Span/Split.cs
+++ b/src/Extensions/ReadOnlySpan/Span/Split.cs
@@ -1,10 +1,11 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 #if !NET9_0_OR_GREATER
 
-namespace System
+namespace SpanExtensions
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public static partial class MemoryExtensions

--- a/src/Extensions/Span/Span/Split.cs
+++ b/src/Extensions/Span/Span/Split.cs
@@ -1,10 +1,11 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 #if !NET9_0_OR_GREATER
 
-namespace System
+namespace SpanExtensions
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public static partial class MemoryExtensions

--- a/src/SpanExtensions.csproj
+++ b/src/SpanExtensions.csproj
@@ -22,7 +22,7 @@
 		<PackageTags>Span;Performance;Extension;String</PackageTags>
 		<PackageReleaseNotes>https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md</PackageReleaseNotes> 
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.5</Version>
+		<Version>1.5.1</Version>
 		<PackageId>SpanExtensions.Net</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/SpanExtensions.csproj
+++ b/src/SpanExtensions.csproj
@@ -1,66 +1,66 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;netstandard2.1</TargetFrameworks>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<Platforms>AnyCPU</Platforms>
-		<Title>Span Extensions</Title>
-		<Authors>dragon-cs</Authors>
-		<Company>draconware</Company>
-		<Description>
-			ReadonlySpan&lt;T&gt; and Span&lt;T&gt; are great Types in C#, but unfortunately working with them can sometimes be sort of a hassle and some use cases seem straight up impossible, even though they are not.
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;netstandard2.1</TargetFrameworks>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <Platforms>AnyCPU</Platforms>
+        <Title>Span Extensions</Title>
+        <Authors>dragon-cs</Authors>
+        <Company>draconware</Company>
+        <Description>
+            ReadonlySpan&lt;T&gt; and Span&lt;T&gt; are great Types in C#, but unfortunately working with them can sometimes be sort of a hassle and some use cases seem straight up impossible, even though they are not.
 
-			SpanExtensions.Net aims to help developers use ReadonlySpan&lt;T&gt; and Span&lt;T&gt; more productively, efficiently and safely and write overall more performant Programs.
+            SpanExtensions.Net aims to help developers use ReadonlySpan&lt;T&gt; and Span&lt;T&gt; more productively, efficiently and safely and write overall more performant Programs.
 
-			Never again switch back to using string instead of ReadonlySpan&lt;T&gt;, just because the method you seek is not supported.
-		</Description>
-		<RepositoryUrl>https://github.com/draconware-dev/SpanExtensions.Net</RepositoryUrl>
-		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Copyright>Copyright (c) 2024 draconware-dev</Copyright>
-		<PackageTags>Span;Performance;Extension;String</PackageTags>
-		<PackageReleaseNotes>https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md</PackageReleaseNotes> 
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.5.1</Version>
-		<PackageId>SpanExtensions.Net</PackageId>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageIcon>icon.png</PackageIcon>
-	</PropertyGroup>
+            Never again switch back to using string instead of ReadonlySpan&lt;T&gt;, just because the method you seek is not supported.
+        </Description>
+        <RepositoryUrl>https://github.com/draconware-dev/SpanExtensions.Net</RepositoryUrl>
+        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+        <Copyright>Copyright (c) 2024 draconware-dev</Copyright>
+        <PackageTags>Span;Performance;Extension;String</PackageTags>
+        <PackageReleaseNotes>https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md</PackageReleaseNotes> 
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <Version>1.5.1</Version>
+        <PackageId>SpanExtensions.Net</PackageId>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>icon.png</PackageIcon>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="README.md">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
-		<None Include="..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="README.md">
+          <Pack>True</Pack>
+          <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
-	<ItemGroup>
-	  <None Include="icon.png">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
-	</ItemGroup>
+    <ItemGroup>
+      <None Include="icon.png">
+        <Pack>True</Pack>
+        <PackagePath>\</PackagePath>
+      </None>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Version 1.5.1 is out to fix incorrect ranges being returned by some custom MemoryExtensions.Split methods.
The custom MemoryExtensions has also been moved from `System` to `SpanExtensions`.

**Issues fixed**:
- https://github.com/draconware-dev/SpanExtensions.Net/issues/25 by @laicasaane

**Full Changelog**: https://github.com/draconware-dev/SpanExtensions.Net/blob/main/Changelog.md